### PR TITLE
Bug Fix: removed CTA button jumping effect

### DIFF
--- a/styles/base.css
+++ b/styles/base.css
@@ -266,7 +266,8 @@ div a.primary-button {
   background: #000;
   font-size: 18px;
   letter-spacing: 0px;
-  /* border: 4px #fff solid; */
+  border: 4px #000 solid;
+  box-sizing: border-box;
   display: inline-block;
   padding: 10px 20px;
   border-radius: 4px;


### PR DESCRIPTION
The call to action button in the home page was making jump effects in the hover state. That was a bad UX for users.

The problem occurred due to increase in padding and appearance of border while in hover state. So I added border at initial state. You should add ```box-sizing: border-box``` to the root of the element in order to get rid of unwanted shifts of elements in the DOM!